### PR TITLE
Make password audits safe and configurable

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,38 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: '7.1'
+            composer: '2.2'
+            phpunit: '^7.5'
+            laravel: '5.6.*'
+          - php: '8.5'
+            composer: latest
+            phpunit: '^12.0'
+            laravel: '^13.0'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer:${{ matrix.composer }}
+          coverage: none
+      - run: composer validate --strict
+      - run: composer require --dev --no-update "phpunit/phpunit:${{ matrix.phpunit }}"
+      - run: composer require --no-update "laravel/framework:${{ matrix.laravel }}"
+      - if: matrix.php == '7.1'
+        run: composer config --no-plugins allow-plugins.kylekatarnls/update-helper false
+      - run: composer update --prefer-stable --no-interaction
+      - run: vendor/bin/phpunit tests

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This package provides an Artisan command to audit the security of your users' passwords.
 
+Supports Laravel 5.6 through 13 and PHP 7.1.3 through current releases. Audit output hides recovered passwords and hashes by default; use `--show-secrets` only in a controlled terminal when the extra data is genuinely required.
+
 Laravel Password Security Audit works by executing a long running process that checks your users passwords against
 a list of over 10k commonly used weak passwords. When complete, it outputs a report of 
 those users that are affected and the passwords that were found. 
@@ -35,23 +37,20 @@ if available.
 User 1   3.6%   33/560168   ETC: 4h 39m   Elapsed: 6s   ▓░░░░░░░░░░░░░░░░░░░  
 ```
 
-When complete, you will be presented with a table of users with weak passwords.
-For each user, this will include the user's primary key (usually the `id` field), 
-the password found and its associated hash.
+When complete, you will be presented with the primary keys of users with weak passwords. Recovered plaintext passwords and hashes are deliberately hidden because terminal logs are often retained.
 
 ```   
 6 user password(s) were found to be weak.
-+----------+----------+--------------------------------------------------------------+
-| Key (id) | Password | Hash                                                         |
-+----------+----------+--------------------------------------------------------------+
-| 1        | password | $2y$10$v6LjwoJOqumnO2A1VmscD.Tnot0D2koOzpGsmVfZaiWM6zprRpwWi |
-| 2        | secret   | $2y$10$em9DONupJiDO1LMnR2PZZeoTOEyNutx4mGscQiKXWCBr09INUAjj6 |
-| 14       | admin    | $2y$10$Kc.6/37NfY.D.JlSFxhyKexUQoo8dDng37MQDl.jSTtwclt7/ypJO |
-| 43       | test123  | $2y$10$Nli8PgRNgTEZE1D1XuiBwOVdxRJJfkVvnWf7N2.Ko93av1ykC4DJO |
-| 54       | secret   | $2y$10$eq6kcNOFC4bYNBDPHOTtC.EAvrQU3IK1kM5/QpwN3FK7HnxPOjR5e |
-| 68       | secret   | $2y$10$Fvl47D2y0uDEr.6waoXzpeyB2k/.nz1SBlygWP12g8TbMEMxp1E4S |
-+----------+----------+--------------------------------------------------------------+
++----------+
+| Key (id) |
++----------+
+| 1        |
+| 2        |
+| 14       |
++----------+
 ``` 
+
+If sensitive output is required, run `php artisan security:password-audit --show-secrets` interactively and avoid redirecting or retaining its output.
 
 ### Custom user model
 

--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,13 @@
   "description": "Laravel Password Security Audit",
   "type": "library",
   "require": {
-    "laravel/framework": "^5.6||^6.0",
+    "php": ">=7.1.3",
+    "laravel/framework": "^5.6 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
     "jord-jd/php-cli-progress-bar": "^4.0",
     "jord-jd/php-password-cracker": "^3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.5"
+    "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^12.0"
   },
   "license": "LGPL-3.0-only",
   "authors": [
@@ -29,7 +30,7 @@
       ]
     },
     "branch-alias": {
-      "dev-master": "3.0-dev"
+      "dev-master": "3.1-dev"
     }
   },
   "replace": {

--- a/src/Console/Commands/PasswordAudit.php
+++ b/src/Console/Commands/PasswordAudit.php
@@ -16,7 +16,7 @@ class PasswordAudit extends Command
      *
      * @var string
      */
-    protected $signature = 'security:password-audit {--user-model=\\App\\User} {--password-field=password}';
+    protected $signature = 'security:password-audit {--user-model=} {--password-field=password} {--show-secrets : Include recovered plaintext passwords and hashes in console output}';
 
     /**
      * The console command description.
@@ -44,28 +44,37 @@ class PasswordAudit extends Command
     public function handle()
     {
         $userModelClass = $this->option('user-model');
+        if (!$userModelClass) {
+            $userModelClass = class_exists('App\\Models\\User') ? 'App\\Models\\User' : 'App\\User';
+        }
         $passwordField = $this->option('password-field');
+
+        if (!is_string($passwordField) || !preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $passwordField)) {
+            $this->error('Specified password field is not a valid column name.');
+
+            return 1;
+        }
 
         if (!class_exists($userModelClass)) {
             $this->error('Specified user model is not a valid class.');
-            exit;
+            return 1;
         }
 
         $userModel = new $userModelClass();
 
         if (!$userModel instanceof Model) {
             $this->error('Specified user model is not a Eloquent model.');
-            exit;
+            return 1;
         }
 
         $query = $userModel->query()
-            ->select([$userModel->getKeyName(), 'password']);
+            ->select([$userModel->getKeyName(), $passwordField]);
 
         $numUsers = $query->count();
 
         if ($numUsers <= 0) {
             $this->error('No users found.');
-            exit;
+            return 1;
         }
 
         $cracker = new DictionaryCracker();
@@ -79,7 +88,7 @@ class PasswordAudit extends Command
 
         $userIndex = 0;
 
-        $query->chunk(1000, function ($users) use ($numPasswords, $crackedUsers, $progressBar, $userIndex, $cracker, $passwordField) {
+        $query->chunk(1000, function ($users) use ($numPasswords, $crackedUsers, $progressBar, &$userIndex, $cracker, $passwordField) {
             /** @var Model $user */
             foreach ($users as $user) {
                 $progressBar
@@ -109,13 +118,18 @@ class PasswordAudit extends Command
 
         $this->line($crackedUsersCount.' user password(s) were found to be weak.');
 
-        if ($crackedUsersCount > 0) {
-            $this->table([
-                'Key ('.$userModel->getKeyName().')',
-                'Password',
-                'Hash'
-            ], $crackedUsers->toArray());
+        if ($crackedUsersCount > 0 && $this->option('show-secrets')) {
+            $this->warn('Recovered plaintext passwords and hashes are sensitive. Do not save or share this output.');
+            $this->table(['Key ('.$userModel->getKeyName().')', 'Password', 'Hash'], $crackedUsers->toArray());
+        } elseif ($crackedUsersCount > 0) {
+            $this->table(
+                ['Key ('.$userModel->getKeyName().')'],
+                $crackedUsers->map(function (CrackedUser $user) {
+                    return $user->toSafeArray();
+                })->toArray()
+            );
         }
 
+        return 0;
     }
 }

--- a/src/Objects/CrackedUser.php
+++ b/src/Objects/CrackedUser.php
@@ -22,6 +22,11 @@ class CrackedUser implements Arrayable
         return $this->key;
     }
 
+    public function toSafeArray()
+    {
+        return ['key' => $this->key];
+    }
+
     public function toArray()
     {
         return [

--- a/tests/PasswordAuditTest.php
+++ b/tests/PasswordAuditTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace JordJD\LaravelPasswordSecurityAudit\Tests;
+
+use JordJD\LaravelPasswordSecurityAudit\Console\Commands\PasswordAudit;
+use JordJD\LaravelPasswordSecurityAudit\Objects\CrackedUser;
+use PHPUnit\Framework\TestCase;
+
+class PasswordAuditTest extends TestCase
+{
+    public function testCrackedUserAutoloadsAndProvidesSafeOutput()
+    {
+        $user = new CrackedUser(42, 'secret', 'hash');
+
+        $this->assertSame(['key' => 42], $user->toSafeArray());
+        $this->assertSame(['key' => 42, 'password' => 'secret', 'hash' => 'hash'], $user->toArray());
+    }
+
+    public function testCommandDeclaresSecretOutputAsOptIn()
+    {
+        $command = new PasswordAudit();
+
+        $this->assertTrue($command->getDefinition()->hasOption('show-secrets'));
+    }
+}


### PR DESCRIPTION
- Fix the `CrackedUser` PSR-4 path so the class autoloads correctly.
- Make the custom password field apply to the database query.
- Auto-detect modern and legacy Laravel user models.
- Hide recovered passwords and hashes by default, with an explicit `--show-secrets` opt-in.
- Fix progress indexing across chunks and return command exit codes instead of terminating PHP.
- Support Laravel 5.6 through 13 while retaining PHP 7.1.3 compatibility.
- Add regression tests and a current CI matrix.
